### PR TITLE
Pin to tornado<4 until compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         version
     ),
     packages=['nsq'],
-    install_requires=['tornado'],
+    install_requires=['tornado<4'],  # <4 due to issue #115
     include_package_data=True,
     zip_safe=False,
     tests_require=['pytest', 'mock', 'simplejson',


### PR DESCRIPTION
Let's pin installs to not exceed the last compatible version of Tornado until #115 is resolved.