### PR TITLE
Triggering the correct "CLOSE" event when the socket is closed

### DIFF
--- a/nsq/async.py
+++ b/nsq/async.py
@@ -226,7 +226,7 @@ class AsyncConn(event.EventedMixin):
 
     def _socket_close(self):
         self.state = DISCONNECTED
-        self.trigger(event.CONNECT, conn=self)
+        self.trigger(event.CLOSE, conn=self)
 
     def close(self):
         self.stream.close()


### PR DESCRIPTION
I suspect this was a typo. The "CONNECT" event was being triggered when the socket was closed. It should instead be the "CLOSE" event.
Regards.