### PR TITLE
Fix exception in Reader.close() when query_periodic is None

### DIFF
--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -262,7 +262,8 @@ class Reader(Client):
             conn.close()
 
         self.redist_periodic.stop()
-        self.query_periodic.stop()
+        if self.query_periodic is not None:
+            self.query_periodic.stop()
 
     def set_message_handler(self, message_handler):
         """

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -171,11 +171,12 @@ class ReaderIntegrationTest(tornado.testing.AsyncTestCase):
                 self.stop()
             return True
 
-        Reader(nsqd_tcp_addresses=['127.0.0.1:4150'], topic=topic, channel='ch',
-               io_loop=self.io_loop, message_handler=handler, max_in_flight=100,
-               **self.identify_options)
+        r = Reader(nsqd_tcp_addresses=['127.0.0.1:4150'], topic=topic, channel='ch',
+                   io_loop=self.io_loop, message_handler=handler, max_in_flight=100,
+                   **self.identify_options)
 
         self.wait()
+        r.close()
 
     def test_reader_heartbeat(self):
         this = self


### PR DESCRIPTION
Fixes bug #122.

Add a call to close to the message test to exercise the code. Verified
the test fails without the fix.