### PR TITLE
Reenable tornado 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,20 @@ python:
 env:
   - NSQ_DOWNLOAD=nsq-0.2.28.linux-amd64.go1.2.1 TORNADO_VERSION=2.4.1
   - NSQ_DOWNLOAD=nsq-0.2.28.linux-amd64.go1.2.1 TORNADO_VERSION=3.2
+  - NSQ_DOWNLOAD=nsq-0.2.28.linux-amd64.go1.2.1 TORNADO_VERSION=4.0
+  - NSQ_DOWNLOAD=nsq-0.2.28.linux-amd64.go1.2.1 TORNADO_VERSION=4.1
   - NSQ_DOWNLOAD=nsq-0.2.30.linux-amd64.go1.3 TORNADO_VERSION=2.4.1
   - NSQ_DOWNLOAD=nsq-0.2.30.linux-amd64.go1.3 TORNADO_VERSION=3.2
+  - NSQ_DOWNLOAD=nsq-0.2.30.linux-amd64.go1.3 TORNADO_VERSION=4.0
+  - NSQ_DOWNLOAD=nsq-0.2.30.linux-amd64.go1.3 TORNADO_VERSION=4.1
   - NSQ_DOWNLOAD=nsq-0.2.31.linux-amd64.go1.3.1 TORNADO_VERSION=2.4.1
   - NSQ_DOWNLOAD=nsq-0.2.31.linux-amd64.go1.3.1 TORNADO_VERSION=3.2
+  - NSQ_DOWNLOAD=nsq-0.2.31.linux-amd64.go1.3.1 TORNADO_VERSION=4.0
+  - NSQ_DOWNLOAD=nsq-0.2.31.linux-amd64.go1.3.1 TORNADO_VERSION=4.1
   - NSQ_DOWNLOAD=nsq-0.3.0.linux-amd64.go1.3.3 TORNADO_VERSION=2.4.1
   - NSQ_DOWNLOAD=nsq-0.3.0.linux-amd64.go1.3.3 TORNADO_VERSION=3.2
+  - NSQ_DOWNLOAD=nsq-0.3.0.linux-amd64.go1.3.3 TORNADO_VERSION=4.0
+  - NSQ_DOWNLOAD=nsq-0.3.0.linux-amd64.go1.3.3 TORNADO_VERSION=4.1
 install:
   - pip install simplejson
   - export PYCURL_SSL_LIBRARY=openssl

--- a/nsq/async.py
+++ b/nsq/async.py
@@ -24,7 +24,14 @@ except ImportError:
 
 import tornado.iostream
 import tornado.ioloop
-import tornado.simple_httpclient
+
+try:
+    from tornado.simple_httpclient import _default_ca_certs as default_ca_certs
+except ImportError:
+    # Tornado < 4
+    from tornado.simple_httpclient import _DEFAULT_CA_CERTS
+    def default_ca_certs():
+        return _DEFAULT_CA_CERTS
 
 from nsq import event, protocol
 from .deflate_socket import DeflateSocket
@@ -265,7 +272,7 @@ class AsyncConn(event.EventedMixin):
 
         opts = {
             'cert_reqs': ssl.CERT_REQUIRED,
-            'ca_certs': tornado.simple_httpclient._DEFAULT_CA_CERTS
+            'ca_certs': default_ca_certs()
         }
         opts.update(options or {})
         self.socket = ssl.wrap_socket(self.socket, ssl_version=ssl.PROTOCOL_TLSv1,

--- a/nsq/deflate_socket.py
+++ b/nsq/deflate_socket.py
@@ -41,3 +41,4 @@ class DeflateSocket(object):
     def send(self, data):
         chunk = self._compressor.compress(data)
         self._socket.send(chunk + self._compressor.flush(zlib.Z_SYNC_FLUSH))
+        return len(data)

--- a/nsq/snappy_socket.py
+++ b/nsq/snappy_socket.py
@@ -40,3 +40,4 @@ class SnappySocket(object):
     def send(self, data):
         chunk = self._compressor.add_chunk(data, compress=True)
         self._socket.send(chunk)
+        return len(data)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         version
     ),
     packages=['nsq'],
-    install_requires=['tornado<4'],  # <4 due to issue #115
+    install_requires=['tornado'],
     include_package_data=True,
     zip_safe=False,
     tests_require=['pytest', 'mock', 'simplejson',


### PR DESCRIPTION
The Snappy & Deflate socket send routines need to return the number of
bytes they sent.

If the underlying socket.send() fails then we're toast.

Update travis to test with tornado 4.0 & 4.1, and update setup.py.