### PR TITLE
asyncconn: catch connection closed error on read_bytes

### DIFF
--- a/nsq/async.py
+++ b/nsq/async.py
@@ -228,8 +228,19 @@ class AsyncConn(event.EventedMixin):
         self._start_read()
         self.trigger(event.CONNECT, conn=self)
 
+    def _read_bytes(self, size, callback):
+        try:
+            self.stream.read_bytes(size, callback)
+        except IOError:
+            self.close()
+            self.trigger(
+                event.ERROR,
+                conn=self,
+                error=protocol.ConnectionClosedError('Stream is closed'),
+            )
+
     def _start_read(self):
-        self.stream.read_bytes(4, self._read_size)
+        self._read_bytes(4, self._read_size)
 
     def _socket_close(self):
         self.state = DISCONNECTED
@@ -241,7 +252,6 @@ class AsyncConn(event.EventedMixin):
     def _read_size(self, data):
         try:
             size = struct.unpack('>l', data)[0]
-            self.stream.read_bytes(size, self._read_body)
         except Exception:
             self.close()
             self.trigger(
@@ -249,6 +259,8 @@ class AsyncConn(event.EventedMixin):
                 conn=self,
                 error=protocol.IntegrityError('failed to unpack size'),
             )
+            return
+        self._read_bytes(size, self._read_body)
 
     def _read_body(self, data):
         try:


### PR DESCRIPTION
If read_bytes is called when the connection is closed and there is nothing in the buffer, an iostream.StreamClosedError is thrown. This is caught in _read_size by the generic exception catcher but uncaught in _start_read.

This can be checked for beforehand by doing checking "if self.stream.closed()" before calling self.stream.read_bytes(). In this case, no buffered data would get processed, but processing the buffered data seems to be the intended behavior of the stream. Of course, processing the buffered data will eventually result in the error log message about not being able to send the FIN.