### PR TITLE
nsq.Reader.disabled() no longer effective

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,21 @@
 language: python
 python:
   - 2.6.9
-  - 2.7.9
+  - 2.7
 env:
-  - NSQ_DOWNLOAD=nsq-0.2.28.linux-amd64.go1.2.1 TORNADO_VERSION=2.4.1
-  - NSQ_DOWNLOAD=nsq-0.2.28.linux-amd64.go1.2.1 TORNADO_VERSION=3.2
-  - NSQ_DOWNLOAD=nsq-0.2.28.linux-amd64.go1.2.1 TORNADO_VERSION=4.0
-  - NSQ_DOWNLOAD=nsq-0.2.28.linux-amd64.go1.2.1 TORNADO_VERSION=4.1
-  - NSQ_DOWNLOAD=nsq-0.2.30.linux-amd64.go1.3 TORNADO_VERSION=2.4.1
   - NSQ_DOWNLOAD=nsq-0.2.30.linux-amd64.go1.3 TORNADO_VERSION=3.2
   - NSQ_DOWNLOAD=nsq-0.2.30.linux-amd64.go1.3 TORNADO_VERSION=4.0
   - NSQ_DOWNLOAD=nsq-0.2.30.linux-amd64.go1.3 TORNADO_VERSION=4.1
-  - NSQ_DOWNLOAD=nsq-0.2.31.linux-amd64.go1.3.1 TORNADO_VERSION=2.4.1
   - NSQ_DOWNLOAD=nsq-0.2.31.linux-amd64.go1.3.1 TORNADO_VERSION=3.2
   - NSQ_DOWNLOAD=nsq-0.2.31.linux-amd64.go1.3.1 TORNADO_VERSION=4.0
   - NSQ_DOWNLOAD=nsq-0.2.31.linux-amd64.go1.3.1 TORNADO_VERSION=4.1
-  - NSQ_DOWNLOAD=nsq-0.3.0.linux-amd64.go1.3.3 TORNADO_VERSION=2.4.1
   - NSQ_DOWNLOAD=nsq-0.3.0.linux-amd64.go1.3.3 TORNADO_VERSION=3.2
   - NSQ_DOWNLOAD=nsq-0.3.0.linux-amd64.go1.3.3 TORNADO_VERSION=4.0
   - NSQ_DOWNLOAD=nsq-0.3.0.linux-amd64.go1.3.3 TORNADO_VERSION=4.1
-install:
-  - pip install simplejson
-  - export PYCURL_SSL_LIBRARY=openssl
-  - pip install pycurl
-  - pip install tornado==$TORNADO_VERSION
-  - sudo apt-get install libsnappy-dev
-  - pip install python-snappy
-  - wget http://bitly-downloads.s3.amazonaws.com/nsq/$NSQ_DOWNLOAD.tar.gz
-  - tar zxvf $NSQ_DOWNLOAD.tar.gz
-  - sudo cp $NSQ_DOWNLOAD/bin/nsqd $NSQ_DOWNLOAD/bin/nsqlookupd /usr/local/bin
-script: py.test
+  - NSQ_DOWNLOAD=nsq-0.3.5.linux-amd64.go1.4.2 TORNADO_VERSION=3.2
+  - NSQ_DOWNLOAD=nsq-0.3.5.linux-amd64.go1.4.2 TORNADO_VERSION=4.1
+script: 
+  - ./travis_test.sh
 notifications:
   email: false
+sudo: false

--- a/travis_test.sh
+++ b/travis_test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+
+pip install simplejson
+export PYCURL_SSL_LIBRARY=openssl
+pip install pycurl
+pip install tornado==$TORNADO_VERSION
+
+# install snappy from source so we can compile with `-fPIC` witout having to sudo install stuff
+git clone https://github.com/google/snappy.git
+cd snappy
+sh autogen.sh
+mkdir $HOME/usr/local
+./configure --prefix=$HOME/usr/local
+CFLAGS="-fPIC" make
+make install
+
+set -e
+
+CPPFLAGS="-I$HOME/usr/local/include -L$HOME/usr/local/lib -fPIC" pip install python-snappy
+wget http://bitly-downloads.s3.amazonaws.com/nsq/$NSQ_DOWNLOAD.tar.gz
+tar zxvf $NSQ_DOWNLOAD.tar.gz
+export PATH=$NSQ_DOWNLOAD/bin:$PATH
+
+LD_LIBRARY_PATH=$HOME/usr/local/lib py.test -q -v


### PR DESCRIPTION
Due to the "don't decrement rdy" change to nsqd behavior (https://github.com/bitly/nsq/pull/404), the current effect of `disabled()` returning `True` in `nsq.Reader`, of not sending any ready count (never calling `_send_rdy()`), fails to reduce the ready count to zero on the nsqd side.